### PR TITLE
la til q3

### DIFF
--- a/Protein.py
+++ b/Protein.py
@@ -68,7 +68,8 @@ class Grid:
 			return np.array([pivotCoords[0], pivotCoords[1] + 1])
 
 		# If target number has not been found:
-		print("\n### ERROR ###\nfunction searchAdjacent cannot find target number", targetNr, "next to initial number\n")
+#		print("\n### ERROR ###\nfunction searchAdjacent cannot find target number", targetNr, "next to initial number\n")
+		# The previous line was removed because it falsely displayed an error in the diameter function
 		return np.array([0, 0])
 
 	def revealAdjacent(self, pivotCoords, side):


### PR DESCRIPTION
diameter-funksjon fremprovoserte feilmeldingen til Protein.searchAdjacent, men den fungerer som den skal. Endret searchAdjacent så den ikke viser feilmelding lenger hvis den ikke finner elementet den leter etter. Den meldingen har uansett lite å si nå som twist funker.

q3 er ingen fullstendig besvarelse av question 3, men det inneholder en funksjon som gir diameteren til et protein

